### PR TITLE
misc: Fix externals leak

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -162,6 +162,7 @@ NAN_METHOD(OboeContext::set) {
 NAN_METHOD(OboeContext::copy) {
   Metadata* md = new Metadata(oboe_context_get());
   info.GetReturnValue().Set(Metadata::NewInstance(md));
+  delete md;
 }
 
 NAN_METHOD(OboeContext::clear) {
@@ -175,6 +176,7 @@ NAN_METHOD(OboeContext::isValid) {
 NAN_METHOD(OboeContext::createEvent) {
   Metadata* md = new Metadata(oboe_context_get());
   info.GetReturnValue().Set(Event::NewInstance(md));
+  delete md;
 }
 
 NAN_METHOD(OboeContext::startTrace) {

--- a/src/event.cc
+++ b/src/event.cc
@@ -154,6 +154,7 @@ NAN_METHOD(Event::getMetadata) {
   oboe_event_t* event = &self->event;
   Metadata* metadata = new Metadata(&event->metadata);
   info.GetReturnValue().Set(Metadata::NewInstance(metadata));
+  delete metadata;
 }
 
 // Get the metadata of an event as a string

--- a/src/metadata.cc
+++ b/src/metadata.cc
@@ -47,7 +47,9 @@ NAN_METHOD(Metadata::fromString) {
     return Nan::ThrowError("Failed to convert Metadata from string");
   }
 
-  info.GetReturnValue().Set(Metadata::NewInstance(new Metadata(&md)));
+  Metadata* metadata = new Metadata(&md);
+  info.GetReturnValue().Set(Metadata::NewInstance(metadata));
+  delete metadata;
 }
 
 // Make a new metadata instance with randomized data
@@ -57,7 +59,9 @@ NAN_METHOD(Metadata::makeRandom) {
   oboe_metadata_random(&md);
 
   // Use the object as an argument in the event constructor
-  info.GetReturnValue().Set(Metadata::NewInstance(new Metadata(&md)));
+  Metadata* metadata = new Metadata(&md);
+  info.GetReturnValue().Set(Metadata::NewInstance(metadata));
+  delete metadata;
 }
 
 // Copy the contents of the metadata instance to a new instance


### PR DESCRIPTION
While wrapped classes are tracked automatically by V8's GC, pointers given to v8::External are not. They need to be deleted after use.