### PR TITLE
nan: Bump nan version for node v6 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "bindings": "~1.2.1",
-    "nan": "~2.0.0"
+    "nan": "~2.2.0"
   },
   "devDependencies": {
     "gulp": "~3.8.11",


### PR DESCRIPTION
This adds support for node v6.